### PR TITLE
Add Redis support

### DIFF
--- a/EuroJudoWebContestSheets/Cache/BlankRedisSubscriber.cs
+++ b/EuroJudoWebContestSheets/Cache/BlankRedisSubscriber.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EuroJudoWebContestSheets.Models.ContestOrder;
+using EuroJudoWebContestSheets.Models.DTO;
+using StackExchange.Redis;
+
+namespace EuroJudoWebContestSheets.Cache
+{
+    public class BlankRedisSubscriber : IRedisSubscriber
+    {
+        public BlankRedisSubscriber()
+        {
+        }
+
+        public async Task PublishContestOrder(List<ContestOrder> contestOrders)
+        {            
+        }
+
+        public async Task PublishTournament(RedisRoundRobinContestSheetDataDto contest)
+        {            
+        }
+
+        private void UpdateContestOrder(RedisChannel channel, RedisValue value)
+        {
+        }
+
+        private void UpdateTournament(RedisChannel channel, RedisValue value)
+        {
+        }
+    }
+}

--- a/EuroJudoWebContestSheets/Cache/CacheHelper.cs
+++ b/EuroJudoWebContestSheets/Cache/CacheHelper.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace EuroJudoWebContestSheets.Cache
+{
+    public class CacheHelper : ICacheHelper
+    {
+        private bool _useRedis = false;
+        private IConnectionMultiplexer _redis;
+        private IMemoryCache _memCache;
+
+        public CacheHelper(IConnectionMultiplexer redis)
+        {
+            _redis = redis;
+            _useRedis = true;
+        }
+
+        public CacheHelper(IMemoryCache memCache)
+        {
+            _memCache = memCache;
+        }
+
+        public async Task<T> SetCache<T>(string key, T entry)
+        {
+            if (_useRedis)
+            {
+                var db = _redis.GetDatabase();
+                await db.StringSetAsync(key, JsonConvert.SerializeObject(entry), new TimeSpan(1, 0, 0));
+            }
+            else
+            {
+                var cacheEntryOptions = new MemoryCacheEntryOptions()
+                .SetPriority(CacheItemPriority.Normal);
+
+                _memCache.Set(key, entry, cacheEntryOptions);
+            }
+
+            return entry;
+        }
+
+        public bool TryGetValue<T>(string key, out T entry)
+        {
+            bool found = false;
+            if (_useRedis)
+            {
+                var db = _redis.GetDatabase();
+                string content = db.StringGet(key);
+                if(content != null)
+                {
+                    found = true;
+                    entry = JsonConvert.DeserializeObject<T>(content);
+                }
+                else
+                {
+                    entry = default;
+                }
+                return found;
+            }
+            else
+            {
+                found = _memCache.TryGetValue(key, out entry);
+                return found;
+            }
+        }
+    }
+}

--- a/EuroJudoWebContestSheets/Cache/ICacheHelper.cs
+++ b/EuroJudoWebContestSheets/Cache/ICacheHelper.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace EuroJudoWebContestSheets.Cache
+{
+    public interface ICacheHelper
+    {
+        public Task<T> SetCache<T>(string key, T entry);
+
+        public bool TryGetValue<T>(string key, out T entry);
+    }
+}

--- a/EuroJudoWebContestSheets/Cache/IRedisSubscriber.cs
+++ b/EuroJudoWebContestSheets/Cache/IRedisSubscriber.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EuroJudoWebContestSheets.Models.ContestOrder;
+using EuroJudoWebContestSheets.Models.DTO;
+
+namespace EuroJudoWebContestSheets.Cache
+{
+    public interface IRedisSubscriber
+    {
+        public Task PublishContestOrder(List<ContestOrder> contestOrders);
+
+        public Task PublishTournament(RedisRoundRobinContestSheetDataDto contest);
+    }
+}

--- a/EuroJudoWebContestSheets/Cache/RedisSubscriber.cs
+++ b/EuroJudoWebContestSheets/Cache/RedisSubscriber.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EuroJudoWebContestSheets.Extentions;
+using EuroJudoWebContestSheets.Hubs;
+using EuroJudoWebContestSheets.Models;
+using EuroJudoWebContestSheets.Models.ContestOrder;
+using EuroJudoWebContestSheets.Models.DTO;
+using Microsoft.AspNetCore.SignalR;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace EuroJudoWebContestSheets.Cache
+{
+    public class RedisSubscriber : IRedisSubscriber
+    {
+        private readonly ISubscriber sub;
+        private readonly IHubContext<ContestOrderHub> contestOrderHub;
+        private readonly IHubContext<TournamentHub> tournamentHub;
+
+        private static readonly string ContestOrderChannel = "contestOrder";
+        private static readonly string TournamentChannel = "tournament";
+
+        public RedisSubscriber(IConnectionMultiplexer redis, IHubContext<ContestOrderHub> contestOrder, IHubContext<TournamentHub> tournament)
+        {
+            sub = redis.GetSubscriber();
+            this.contestOrderHub = contestOrder;
+            this.tournamentHub = tournament;
+
+            sub.SubscribeAsync(ContestOrderChannel, UpdateContestOrder);
+            sub.SubscribeAsync(TournamentChannel, UpdateTournament);
+        }
+
+        public async Task PublishContestOrder(List<ContestOrder> contestOrders)
+        {
+            await sub.PublishAsync(ContestOrderChannel, JsonConvert.SerializeObject(contestOrders));
+        }
+
+        public async Task PublishTournament(RedisRoundRobinContestSheetDataDto contest)
+        {
+            await sub.PublishAsync(TournamentChannel, JsonConvert.SerializeObject(contest));
+        }
+
+        private void UpdateContestOrder(RedisChannel channel, RedisValue value)
+        {
+            string messageString = (string)value;
+            List<ContestOrder> contestOrders = JsonConvert.DeserializeObject<List<ContestOrder>>(messageString);
+            contestOrderHub.Clients.All.SendAsync("updateContestOrder", contestOrders);
+        }
+
+        private void UpdateTournament(RedisChannel channel, RedisValue value)
+        {
+            string messageString = (string)value;
+            RedisRoundRobinContestSheetDataDto contestData = JsonConvert.DeserializeObject<RedisRoundRobinContestSheetDataDto>(messageString);
+            if (contestData.ContestType == ContestType.RoundRobin)
+            {
+                tournamentHub.Clients.Group($"t{contestData.TournamentID}c{contestData.CategoryID}").SendAsync("updateSheet", contestData.ToRoundRobinDto());
+            }
+            else
+            {
+                tournamentHub.Clients.Group($"t{contestData.TournamentID}c{contestData.CategoryID}").SendAsync("updateSheet", contestData.ToDTO());
+            }
+        }
+    }
+}

--- a/EuroJudoWebContestSheets/Controllers/ContestOrderController.cs
+++ b/EuroJudoWebContestSheets/Controllers/ContestOrderController.cs
@@ -10,10 +10,11 @@ namespace EuroJudoWebContestSheets.Controllers
 {
     public class ContestOrderController : Controller
     {
+        private readonly IRedisSubscriber _subscriber;
         private readonly ICacheHelper _cache;
         private readonly IHubContext<ContestOrderHub> _hub;
 
-        public ContestOrderController(ICacheHelper cache, IHubContext<ContestOrderHub> hub)
+        public ContestOrderController(ICacheHelper cache, IHubContext<ContestOrderHub> hub,  IRedisSubscriber subscriber)
         {
             _hub = hub;
             _cache = cache;
@@ -42,6 +43,7 @@ namespace EuroJudoWebContestSheets.Controllers
         public async Task<IActionResult> PostContestOrderLists([FromBody] List<ContestOrder> contestOrders)
         {
             await _cache.SetCache<List<ContestOrder>>("contestOrders", contestOrders);
+            await _subscriber.PublishContestOrder(contestOrders);
             await _hub.Clients.All.SendAsync("updateContestOrder", contestOrders);
 
             return Ok();

--- a/EuroJudoWebContestSheets/Controllers/ContestOrderController.cs
+++ b/EuroJudoWebContestSheets/Controllers/ContestOrderController.cs
@@ -18,6 +18,7 @@ namespace EuroJudoWebContestSheets.Controllers
         {
             _hub = hub;
             _cache = cache;
+            _subscriber = subscriber;
         }
 
         public IActionResult Index()

--- a/EuroJudoWebContestSheets/Extentions/ContestDataExtentions.cs
+++ b/EuroJudoWebContestSheets/Extentions/ContestDataExtentions.cs
@@ -70,6 +70,66 @@ namespace EuroJudoWebContestSheets.Extentions
             };
         }
 
+        public static RedisRoundRobinContestSheetDataDto ToRedisDTO(this ContestSheetDataDto contest, ContestType type)
+        {
+            return new RedisRoundRobinContestSheetDataDto
+            {
+                Contest = contest.Contest,
+                CompetitorWhite = contest.CompetitorWhite,
+                CompetitorBlue = contest.CompetitorBlue,
+                IponWhite = contest.IponWhite,
+                WazaariWhite = contest.WazaariWhite,
+                IponBlue = contest.IponBlue,
+                WazaariBlue = contest.WazaariBlue,
+                ContestType = type,
+            };
+        }
+
+        public static RedisRoundRobinContestSheetDataDto ToRedisDTO(this RoundRobinSheetDataDto contest, ContestType type)
+        {
+            return new RedisRoundRobinContestSheetDataDto
+            {
+                Contest = contest.Contest,
+                CompetitorWhite = contest.CompetitorWhite,
+                CompetitorBlue = contest.CompetitorBlue,
+                IponWhite = contest.IponWhite,
+                WazaariWhite = contest.WazaariWhite,
+                IponBlue = contest.IponBlue,
+                WazaariBlue = contest.WazaariBlue,
+                Competitors = contest.Competitors,
+                ContestType = type,
+            };
+        }
+
+        public static ContestSheetDataDto ToDTO(this RedisRoundRobinContestSheetDataDto contest)
+        {
+            return new ContestSheetDataDto
+            {
+                Contest = contest.Contest,
+                CompetitorWhite = contest.CompetitorWhite,
+                CompetitorBlue = contest.CompetitorBlue,
+                IponWhite = contest.IponWhite,
+                WazaariWhite = contest.WazaariWhite,
+                IponBlue = contest.IponBlue,
+                WazaariBlue = contest.WazaariBlue,
+            };
+        }
+
+        public static RoundRobinSheetDataDto ToRoundRobinDto(this RedisRoundRobinContestSheetDataDto contest)
+        {
+            return new RoundRobinSheetDataDto
+            {
+                Contest = contest.Contest,
+                CompetitorWhite = contest.CompetitorWhite,
+                CompetitorBlue = contest.CompetitorBlue,
+                IponWhite = contest.IponWhite,
+                WazaariWhite = contest.WazaariWhite,
+                IponBlue = contest.IponBlue,
+                WazaariBlue = contest.WazaariBlue,
+                Competitors = contest.Competitors,
+            };
+        }
+
         public static RoundRobinSheetDataDto ToRoundRobinDto(this ContestSheetData contest, Category category)
         {
             List<CompetitorDto> competitors = new List<CompetitorDto>();
@@ -570,7 +630,7 @@ namespace EuroJudoWebContestSheets.Extentions
                         Points = score,
                     };
                 case 6:
-                    asBlue = category.SheetData.Where(s => s.Contest == 3 || s.Contest == 6 || s.Contest == 9 || s.Contest == 11  || s.Contest == 13);
+                    asBlue = category.SheetData.Where(s => s.Contest == 3 || s.Contest == 6 || s.Contest == 9 || s.Contest == 11 || s.Contest == 13);
                     return new EventResult
                     {
                         Won = asBlue.Where(c => !c.WhiteWon()).Count(),

--- a/EuroJudoWebContestSheets/Hubs/ContestOrderHub.cs
+++ b/EuroJudoWebContestSheets/Hubs/ContestOrderHub.cs
@@ -1,19 +1,28 @@
-﻿using EuroJudoWebContestSheets.Models;
+﻿using EuroJudoWebContestSheets.Cache;
 using EuroJudoWebContestSheets.Models.ContestOrder;
 using Microsoft.AspNetCore.SignalR;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace EuroJudoWebContestSheets.Hubs
 {
     public class ContestOrderHub : Hub
     {
+        private readonly ICacheHelper cache;
+
+        public ContestOrderHub(ICacheHelper cache)
+        {
+            this.cache = cache;
+        }
+
         public override async Task OnConnectedAsync()
         {
-            await Clients.Client(Context.ConnectionId).SendAsync("connected", "Hello from ContestOrderHub");
             await base.OnConnectedAsync();
+            await Clients.Client(Context.ConnectionId).SendAsync("connected", "Hello from ContestOrderHub");
+            if (!cache.TryGetValue("contestOrders", out List<ContestOrder> contestOrders))
+            {
+                await cache.SetCache<List<ContestOrder>>("contestOrders", contestOrders);
+            }
         }
 
         public async Task updateContestOrder(List<ContestOrder> contestOrders)

--- a/EuroJudoWebContestSheets/Models/DTO/RedisRoundRobinContestSheetDataDto.cs
+++ b/EuroJudoWebContestSheets/Models/DTO/RedisRoundRobinContestSheetDataDto.cs
@@ -1,0 +1,11 @@
+namespace EuroJudoWebContestSheets.Models.DTO
+{
+    public class RedisRoundRobinContestSheetDataDto : RoundRobinSheetDataDto
+    {
+        public ContestType ContestType { get; set; }
+
+        public int TournamentID { get; set; }
+
+        public int CategoryID { get; set; }
+    }
+}

--- a/EuroJudoWebContestSheets/Startup.cs
+++ b/EuroJudoWebContestSheets/Startup.cs
@@ -33,8 +33,6 @@ namespace EuroJudoWebContestSheets
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-
-
             services.AddDbContext<dbContext>();
 
             //services.AddControllers();
@@ -55,10 +53,12 @@ namespace EuroJudoWebContestSheets
                 string redisHost = Configuration["RedisHost"] ?? throw new InvalidOperationException("Missing required configuration parameter [RedisHost].");
                 var redisMultiplexer = ConnectionMultiplexer.Connect(redisHost);
                 services.AddSingleton<IConnectionMultiplexer>(redisMultiplexer);
+                services.AddSingleton<IRedisSubscriber, RedisSubscriber>();
             }
             else
             {
                 services.AddMemoryCache();
+                services.AddSingleton<IRedisSubscriber, BlankRedisSubscriber>();
             }
 
             services.AddScoped<ICacheHelper, CacheHelper>();

--- a/EuroJudoWebContestSheets/Startup.cs
+++ b/EuroJudoWebContestSheets/Startup.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Hosting;
 using EuroJudoWebContestSheets.Hubs;
 using Microsoft.AspNetCore.HttpOverrides;
 using System;
+using StackExchange.Redis;
+using EuroJudoWebContestSheets.Cache;
 
 namespace EuroJudoWebContestSheets
 {
@@ -31,7 +33,7 @@ namespace EuroJudoWebContestSheets
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-            services.AddMemoryCache();
+
 
             services.AddDbContext<dbContext>();
 
@@ -47,6 +49,19 @@ namespace EuroJudoWebContestSheets
                 hubOptions.KeepAliveInterval = TimeSpan.FromSeconds(3);
             }
             );
+
+            if (bool.TryParse(Configuration["UseRedis"], out bool useRedis) && useRedis)
+            {
+                string redisHost = Configuration["RedisHost"] ?? throw new InvalidOperationException("Missing required configuration parameter [RedisHost].");
+                var redisMultiplexer = ConnectionMultiplexer.Connect(redisHost);
+                services.AddSingleton<IConnectionMultiplexer>(redisMultiplexer);
+            }
+            else
+            {
+                services.AddMemoryCache();
+            }
+
+            services.AddScoped<ICacheHelper, CacheHelper>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Add Redis support, both as caching and as message broker.
Redis can be enabled by setting the config (either through json or as environment) variables "RedisHost" and "UseRedis".

Closes #17 